### PR TITLE
Add missing symbol/footprint tables

### DIFF
--- a/fp-lib-table
+++ b/fp-lib-table
@@ -1,0 +1,6 @@
+(fp_lib_table
+  (lib (name hanrun)(type KiCad)(uri ${KIPRJMOD}/footprints/hanrun.pretty)(options "")(descr ""))
+  (lib (name USB-MICRO-MK5P-2)(type KiCad)(uri ${KIPRJMOD}/footprints/USB-MICRO-MK5P-2.pretty)(options "")(descr ""))
+  (lib (name wson8-8x6mm)(type KiCad)(uri ${KIPRJMOD}/footprints/wson8-8x6mm.pretty)(options "")(descr ""))
+  (lib (name s2qfn80)(type KiCad)(uri ${KIPRJMOD}/footprints/s2qfn80.pretty)(options "")(descr ""))
+)

--- a/sym-lib-table
+++ b/sym-lib-table
@@ -1,0 +1,8 @@
+(sym_lib_table
+  (lib (name ea3036c)(type Legacy)(uri ${KIPRJMOD}/symbols/ea3036c.lib)(options "")(descr ""))
+  (lib (name ch340e)(type Legacy)(uri ${KIPRJMOD}/symbols/ch340e.lib)(options "")(descr ""))
+  (lib (name hanrun)(type Legacy)(uri ${KIPRJMOD}/symbols/hanrun.lib)(options "")(descr ""))
+  (lib (name msc313e)(type Legacy)(uri ${KIPRJMOD}/symbols/msc313e.lib)(options "")(descr ""))
+  (lib (name spinor)(type Legacy)(uri ${KIPRJMOD}/symbols/spinor.lib)(options "")(descr ""))
+  (lib (name tvsarray)(type Legacy)(uri ${KIPRJMOD}/symbols/tvsarray.lib)(options "")(descr ""))
+)


### PR DESCRIPTION
The repository is missing the fp-lib-table and sym-lib-table files which
makes problems when editing/viewing schematics on freshly cloned repo.
The provided tables uses ${KIPRJMOD} to be independent from the path in
the file system.